### PR TITLE
Use regex to parse commands with ranges and arguments

### DIFF
--- a/src/ed.c
+++ b/src/ed.c
@@ -32,13 +32,14 @@ int ed()
 	Command *command;
 	function func;
 
+	init_regex();
 	cmdstr = charalloc(BUFFSIZE);
+	curbuf = new_buffer(NULL);
 	/* Main Loop
 	 *
 	 * Get a command
 	 * Parse the command
 	 * Execute the command */
-	curbuf = new_buffer(NULL);
 	while (fgets(cmdstr, BUFFSIZE, stdin) != NULL) {
 		command = new_command(cmdstr);
 		func = find_function(command);

--- a/src/ed.h
+++ b/src/ed.h
@@ -17,9 +17,9 @@
 
 typedef struct Range {
 	/* Beginning line */
-	int beg;
+	long beg;
 	/* Ending line */
-	int end;
+	long end;
 } Range;
 
 typedef struct Command {
@@ -78,9 +78,10 @@ ssize_t read_file(Buffer *buffer, const char *path);
 ssize_t write_buffer(const char *path);
 
 /* cmds.c */
+void init_regex();
 function find_function(Command *command);
-Command *parse_command(Command *command, char *cmdstr);
-Command *new_command(char *cmdstr);
+Command *parse_command(Command *command, const char *cmdstr);
+Command *new_command(const char *cmdstr);
 void delete_command(Command *command);
 void append(Command *command);
 void find(Command *command);


### PR DESCRIPTION
It enables us to parse commands with associated range and arguments.
