### PR TITLE
Fix some bugs in commands

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -251,18 +251,17 @@ void print(Command *command)
 void read_in(Command *command)
 {
 	ssize_t retval;
-	char path[PATH_MAX];
 
 	if (strlen(curbuf->path) == 0 && strlen(command->arg) == 0) {
 		unknown(command);
 		return;
 	}
 
-	strcpy(path, (strlen(command->arg) != 0) ? command->arg : curbuf->path);
 	if (strlen(curbuf->path) == 0) {
-		strcpy(curbuf->path, path);
+		strcpy(curbuf->path, command->arg);
 	}
-	retval = read_file(curbuf, path);
+	retval = read_file(curbuf,
+			(strlen(command->arg) != 0) ? command->arg : curbuf->path);
 	if (retval < 0) {
 		unknown(command);
 		return;

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -216,6 +216,10 @@ void print(Command *command)
 	beg_no = command->range.beg;
 	end_no = command->range.end;
 
+	if (curbuf->first_line == NULL) {
+		unknown(command);
+		return;
+	}
 	if (beg_no > curbuf->last_line->line_no ||
 			end_no > curbuf->last_line->line_no) {
 		unknown(command);

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -306,7 +306,11 @@ void write_out(Command *command)
 
 void quit(Command *command)
 {
-	/* TODO: Check if buffer was modified before exit */
+	if (curbuf->modified) {
+		curbuf->modified = false;
+		unknown(command);
+		return;
+	}
 	exit(EXIT_SUCCESS);
 }
 

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -253,11 +253,6 @@ void read_in(Command *command)
 	ssize_t retval;
 	char path[PATH_MAX];
 
-	if (curbuf->modified) {
-		curbuf->modified = false;
-		unknown(command);
-		return;
-	}
 	if (strlen(curbuf->path) == 0 && strlen(command->arg) == 0) {
 		unknown(command);
 		return;

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -147,7 +147,6 @@ Command *parse_command(Command *command, const char *cmdstr)
 
 void append(Command *command)
 {
-	int ch;
 	int line_no;
 	char *charbuf;
 

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -270,6 +270,13 @@ void read_in(Command *command)
 		unknown(command);
 		return;
 	}
+
+	/* Renumber the buffer */
+	int i;
+	Line *p;
+	for (i = 1, p = curbuf->first_line; p != NULL; p = p->next, i++) {
+		p->line_no = i;
+	}
 	printf("%ld\n", retval);
 }
 


### PR DESCRIPTION
For the read command, do not check if buffer was modified since it's non-destructive.
Renumber the buffer when a new file is read into it.
For the print command, return if the buffer is empty.
